### PR TITLE
Use img.shields.io for version badges

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# nconf-yaml <sup>[![Version Badge](http://vb.teelaun.ch/tellnes/nconf-yaml.svg)](https://npmjs.org/package/nconf-yaml)</sup>
+# nconf-yaml <sup>[![Version Badge](https://img.shields.io/npm/v/nconf-yaml.svg)](https://npmjs.org/package/nconf-yaml)</sup>
 
 [![Dependency Status](https://david-dm.org/tellnes/nconf-yaml.png)](https://david-dm.org/tellnes/nconf-yaml)
 [![Tips](https://img.shields.io/gratipay/tellnes.svg)](https://gratipay.com/tellnes/)


### PR DESCRIPTION
Noticed this link was broken. I've found http://shields.io to be very reliable.
